### PR TITLE
Correct README.md hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A schema package for [Webhook To Fedora Messaging](http://github.com/fedora-infra/webhook-to-fedora-messaging).
 
-See the [detailed documentation](https://fedora-messaging.readthedocs.io/en/latest/messages.html) on packaging your schemas.
+See the [detailed documentation](https://fedora-messaging.readthedocs.io/en/stable/user-guide/messages.html#packaging) on packaging your schemas.
 
 ![PyPI](https://img.shields.io/pypi/v/webhook-to-fedora-messaging-messages.svg)
 ![Supported Python versions](https://img.shields.io/pypi/pyversions/webhook-to-fedora-messaging-messages.svg)


### PR DESCRIPTION
The [detailed documentation](https://fedora-messaging.readthedocs.io/en/latest/messages.html) hyperlink in the current `README.md` is "broken".

This PR attempts to correct it (but I had to guess as to what the correct value should be...).